### PR TITLE
Enables code snippet previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # copy-github-url README
 
-"copy-github-url" enable you to copy github URL like 'https://github.com/t-mrt/gocha/blob/ac70bd6b39251910fd533ec4a2f6469c8595b700/cmd/gocha/cli.go/#L11-L24'
+"copy-github-url" enable you to copy github URL like 'https://github.com/t-mrt/gocha/blob/ac70bd6b39251910fd533ec4a2f6469c8595b700/cmd/gocha/cli.go#L11-L24'
 
 ## Features
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "copy-github-url",
   "displayName": "copy-github-url",
   "description": "Copy Github URL",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "publisher": "t-mrt",
   "license": "MIT",
   "engines": {

--- a/src/copy-github-URL.ts
+++ b/src/copy-github-URL.ts
@@ -40,7 +40,7 @@ export function buildGithubURL(args: {
 }) {
 
     const L = args.line.start === args.line.end ? `L${args.line.start}` : `L${args.line.start}-L${args.line.end}`;
-    const u = url.parse(`https://${args.domain}/${args.repository}/blob/${args.commit}/${args.filePath}/#${L}`);
+    const u = url.parse(`https://${args.domain}/${args.repository}/blob/${args.commit}/${args.filePath}#${L}`);
     return u.href;
 }
 

--- a/test/copy-github-URL.test.ts
+++ b/test/copy-github-URL.test.ts
@@ -22,7 +22,7 @@ origin  git@github.com:t-mrt/copy-github-url.git (push)
             rootDir: "/User/test/test",
             showInformationMessage: (m: string) => { message = m; },
         });
-        assert.equal("copy! https://github.com/t-mrt/copy-github-url/blob/7332779b314e5aed7496bbacda35514655ef6399/test/test/test.pl/#L2-L5", message);
+        assert.equal("copy! https://github.com/t-mrt/copy-github-url/blob/7332779b314e5aed7496bbacda35514655ef6399/test/test/test.pl#L2-L5", message);
     });
 });
 
@@ -30,7 +30,7 @@ suite("buildGithubURL", () => {
 
     test("multi line", () => {
 
-        assert.equal("https://github.com/t-mrt/copy-github-url/blob/7332779b314e5aed7496bbacda35514655ef6399//t/test.t/#L2-L3", myExtension.buildGithubURL({
+        assert.equal("https://github.com/t-mrt/copy-github-url/blob/7332779b314e5aed7496bbacda35514655ef6399//t/test.t#L2-L3", myExtension.buildGithubURL({
             commit: "7332779b314e5aed7496bbacda35514655ef6399",
             domain: "github.com",
             filePath: "/t/test.t",
@@ -44,7 +44,7 @@ suite("buildGithubURL", () => {
 
     test("single line", () => {
 
-        assert.equal("https://github.com/t-mrt/copy-github-url/blob/7332779b314e5aed7496bbacda35514655ef6399//t/test.t/#L2", myExtension.buildGithubURL({
+        assert.equal("https://github.com/t-mrt/copy-github-url/blob/7332779b314e5aed7496bbacda35514655ef6399//t/test.t#L2", myExtension.buildGithubURL({
             commit: "7332779b314e5aed7496bbacda35514655ef6399",
             domain: "github.com",
             filePath: "/t/test.t",


### PR DESCRIPTION
This commit removes the slash before the hash (`/#L9` --> `#L9`). Github permalinks should not include this slash before the hash (the slash still works for linking but breaks [code snippet previews](https://help.github.com/articles/creating-a-permanent-link-to-a-code-snippet))

# Effect of change:
Pasting a permalink **before**
https://github.com/t-mrt/copy-github-url/blob/b7a936b43d455c13effe76a1b27a6f65732b8e85/src/copy-github-URL.ts/#L43

and **after**
https://github.com/t-mrt/copy-github-url/blob/b7a936b43d455c13effe76a1b27a6f65732b8e85/src/copy-github-URL.ts#L43